### PR TITLE
fix: hadolint fixes for Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # singlestore-logistics-sim
 
 Future home of a large scale logistics demo using SingleStore and Redpanda.  Stay tuned :)
+
+## Usage
+
+1. [Sign up](https://msql.co/2E8aBa2) for a free SingleStore license.
+This allows you to run up to 4 nodes up to 32 gigs each for free. Grab your license key from [SingleStore portal](https://msql.co/3fZoxjO) and set it as an environment variable.
+
+2. Run the simulation with `docker-compose up`.
+
+```bash
+export SINGLESTORE_LICENSE="<<singlestore license>>"
+docker-compose up
+```

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -3,9 +3,8 @@ FROM golang:1.15
 WORKDIR /go/src/simulator
 COPY . .
 
-RUN go mod download
-RUN go get github.com/githubnemo/CompileDaemon
+RUN go mod download && \
+    go get github.com/githubnemo/CompileDaemon && \
+    go install -v ./...
 
-RUN go install -v ./...
-
-CMD CompileDaemon --build="go install ./..." --command="simulator"
+CMD ["CompileDaemon", "--build='go install ./...'", "--command='simulator'"]


### PR DESCRIPTION
Add basic usage section to readme (snipped from other labs).

Identified some minor nits from hadolint by running:

```bash
cd simulator
docker run --rm -i ghcr.io/hadolint/hadolint < Dockerfile
```

In README, may also want to mention the other related projects, e.g. 

- https://github.com/singlestore-labs/singlestore-avro-sample
- https://github.com/memsql/pipelines-twitter-demo
- https://github.com/memsql/singlestore-kafka-connector